### PR TITLE
3 camera clamping crashes the game on worlds smaller than the viewport

### DIFF
--- a/src/_sandbox/CMakeLists.txt
+++ b/src/_sandbox/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(_sandbox
   ai_random_move.cc
   animation.cc
   background.cc
+  clamp.cc
   collision.cc
   decl.hh
   position.cc

--- a/src/_sandbox/clamp.cc
+++ b/src/_sandbox/clamp.cc
@@ -1,0 +1,30 @@
+#include "_sandbox/decl.hh"
+#include "logic/components.hh"
+#include "logic/movement.hh"
+#include "logic/world.hh"
+#include "logic/zsort.hh"
+
+
+yumeami::World yumeami::sandbox::create_clamp_world() {
+  World world = create_world(
+      {
+          .width = 10,
+          .height = 5,
+          .tile_size = 16,
+          .wrap = false,
+          .clamp_camera = true,
+      },
+      {.sheet_ids = {}});
+  WorldState &wstate = world.state;
+
+  entt::entity p = wstate.reg.create();
+  wstate.reg.emplace<DrawPos>(p, 0, 0);
+  wstate.reg.emplace<TruePos>(p, 0, 0);
+  wstate.reg.emplace<MovementState>(p);
+  wstate.reg.emplace<Velocity>(p, 0.4f);
+  wstate.reg.emplace<PlayerTag>(p);
+  wstate.reg.emplace<CameraTargetTag>(p);
+  emplace_zsort(wstate.reg, p);
+
+  return world;
+}

--- a/src/_sandbox/decl.hh
+++ b/src/_sandbox/decl.hh
@@ -13,5 +13,6 @@ namespace yumeami::sandbox {
   World create_animation_world(SheetCache &cache);
   World create_background_world(SheetCache &sheet_cache,
                                 TextureCache &tex_cache);
+  World create_clamp_world();
 
 } // namespace yumeami::sandbox

--- a/src/logic/camera.cc
+++ b/src/logic/camera.cc
@@ -17,23 +17,33 @@ namespace {
   void update_camera_target(WorldState &wstate, const WorldConfig &wconfig,
                             const DrawPos &draw_pos, const SafeRenderTex &vp) {
     // clang-format off
-    float intended_target_x = floorf((draw_pos.x + 1) * wconfig.tile_size * wconfig.scale);
-    float intended_target_y = floorf((draw_pos.y + 1) * wconfig.tile_size * wconfig.scale);
+    float intended_target_x = floorf((draw_pos.x + 0.5) * wconfig.tile_size * wconfig.scale);
+    float intended_target_y = floorf((draw_pos.y + 0.5) * wconfig.tile_size * wconfig.scale);
     // clang-format on
 
     // NOTE: as of now, clamp_camera being activated on a world smaller than the
     // viewport leads to the game crashing. The crash is caused by std::clamp
     // bounds failing assertions.
     if (wconfig.clamp_camera) {
-      // clang-format off
-      float bound_x = wconfig.width * wconfig.tile_size * wconfig.scale;
-      float bound_y = wconfig.height * wconfig.tile_size * wconfig.scale;
 
+      float wwidth = wconfig.width * wconfig.tile_size * wconfig.scale;
+      float wheight = wconfig.height * wconfig.tile_size * wconfig.scale;
       float halfscr_width = vp->texture.width / (2.0 * wstate.cam.zoom);
       float halfscr_height = vp->texture.height / (2.0 * wstate.cam.zoom);
-      float real_target_x = std::clamp(intended_target_x, halfscr_width, bound_x - halfscr_width);
-      float real_target_y = std::clamp(intended_target_y, halfscr_height, bound_y - halfscr_height);
-      // clang-format on
+      float real_target_y{};
+      float real_target_x{};
+
+      if (wwidth < vp->texture.width)
+        real_target_x = wwidth / 2;
+      else
+        real_target_x = std::clamp(intended_target_x, halfscr_width,
+                                   wwidth - halfscr_width);
+
+      if (wheight < vp->texture.height)
+        real_target_y = wheight / 2;
+      else
+        real_target_y = std::clamp(intended_target_y, halfscr_height,
+                                   wheight - halfscr_height);
 
       wstate.cam.target = Vector2{
           .x = real_target_x,

--- a/src/logic/camera.cc
+++ b/src/logic/camera.cc
@@ -21,9 +21,6 @@ namespace {
     float intended_target_y = floorf((draw_pos.y + 0.5) * wconfig.tile_size * wconfig.scale);
     // clang-format on
 
-    // NOTE: as of now, clamp_camera being activated on a world smaller than the
-    // viewport leads to the game crashing. The crash is caused by std::clamp
-    // bounds failing assertions.
     if (wconfig.clamp_camera) {
 
       float wwidth = wconfig.width * wconfig.tile_size * wconfig.scale;

--- a/src/logic/camera.hh
+++ b/src/logic/camera.hh
@@ -24,7 +24,9 @@ namespace yumeami {
    *
    * @param world
    * @param vp
-   * @param clamp if true, clamp the target to the boundaries of the world
+   * @param clamp if true, clamp the target to the boundaries of the world. If
+   * the world is smaller than the viewport, then the camera will target the
+   * center of the world.
    */
   void update_camera(World &world, const SafeRenderTex &vp, bool log = false);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,8 +32,7 @@ int main(int argc, char *argv[]) {
 
   yumeami::SpritesheetCache spritesheet_cache{};
   yumeami::TextureCache texture_cache{};
-  yumeami::World world = yumeami::sandbox::create_background_world(
-      spritesheet_cache, texture_cache);
+  yumeami::World world = yumeami::sandbox::create_clamp_world();
   yumeami::setup_camera(world, vp);
 
   entt::dispatcher dispatcher{};
@@ -60,6 +59,7 @@ int main(int argc, char *argv[]) {
     BeginTextureMode(vp);
     ClearBackground(BLACK);
     yumeami::draw_world(world, spritesheet_cache, texture_cache, vp);
+    yumeami::draw_debug_world_bounds(world);
     EndTextureMode();
 
     // draw on window


### PR DESCRIPTION
- camera now targets the center of the world when clamped in world smaller than viewport
- camera now perfectly centers the player. We used to go with yume nikki's camera targeting behavior, but on second thought, it might be better to simply center the camera on the player.